### PR TITLE
Update workflow to create PR instead of pushing directly

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - chore/autodoc-workflow
   workflow_dispatch:
 
 jobs:
@@ -34,9 +35,20 @@ jobs:
       - name: Checkout api-docs repository
         uses: actions/checkout@v4
         with:
-          repository: kscale/api-docs
+          repository: kscalelabs/api-docs
           path: api-docs
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.API_DOCS_TOKEN }}
+          ssh-strict: true
+          ssh-user: git
+          persist-credentials: true
+          clean: true
+          sparse-checkout-cone-mode: true
+          fetch-depth: 1
+          fetch-tags: false
+          show-progress: true
+          lfs: false
+          submodules: false
+          set-safe-directory: true
 
       - name: Copy documentation to api-docs
         run: |

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -55,11 +55,15 @@ jobs:
           mkdir -p api-docs/kos-sdk
           cp -r docs/kos_sdk/* api-docs/kos-sdk/
 
-      - name: Commit changes to api-docs
+      - name: Create PR for api-docs
         run: |
           cd api-docs
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
+          git checkout -b update-docs-${{ github.sha }}
           git add .
           git commit -m "Update demos documentation from ${{ github.sha }}" || echo "No changes to commit"
-          git push
+          git push -u origin update-docs-${{ github.sha }}
+          gh pr create --title "Update documentation" --body "Auto-generated documentation update from commit ${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.API_DOCS_TOKEN }}


### PR DESCRIPTION
Modify the documentation workflow to create a PR instead of pushing directly to master in the api-docs repository.